### PR TITLE
ENG-1068 Include message support for data disbursement API

### DIFF
--- a/message/send.mdx
+++ b/message/send.mdx
@@ -4,12 +4,21 @@ openapi: "POST /message/{serviceId}"
 ---
 
 <Note>
-  Refer to [Authentication](/authentication) for information on how to obtain a
-  bearer token. This endpoint requires the `message.sms.send.oneway` API client
-  authorization scope to send one way messages. You can set up scopes on the
-  [API Clients](https://cloud.belio.co.ke/team-overview/api-access-keys) page.
+    Refer to [Authentication](/authentication) for information on how to obtain a
+    bearer token. This endpoint requires the `message.sms.send.oneway` API client
+    authorization scope to send one way messages. You can set up scopes on the
+    [API Clients](https://cloud.belio.co.ke/team-overview/api-access-keys) page.
 </Note>
 
 ### Rate Limit
 
 This endpoint is rate limited to **400** messages per second.
+
+## Request Modes
+
+The API supports two request modes:
+
+- `SendToMany` — same message is sent to multiple recipients
+- `SendToEach` — message is sent to individual recipients.(Messages can be tailored for each recipient)
+
+Both modes support a maximum of **100** recipients per request and a **960** character limit for each message.

--- a/mobile-data/delivery-receipt.mdx
+++ b/mobile-data/delivery-receipt.mdx
@@ -13,6 +13,14 @@ This enables real-time monitoring of data disbursement success, failure, or pend
   Ensure that the callback URL is publicly accessible and can accept incoming HTTP `POST` requests without requiring authentication.
 </Note>
 
+<Note>
+  If you enabled optional SMS notifications (`messaging`), the callback URL may also receive SMS delivery receipts. SMS receipts use the same format as the Message API delivery receipts; see [Message Delivery Receipts](/message/delivery-receipt).
+</Note>
+
+<Note>
+  Receipts may be delivered asynchronously and out of order.
+</Note>
+
 ## Delivery Receipt Format
 
 A delivery receipt is sent as an HTTP `POST` request to the specified callback URL containing the following JSON payload:
@@ -50,7 +58,7 @@ A delivery receipt is sent as an HTTP `POST` request to the specified callback U
 | Status                | Description                                                                                   |
 |-----------------------|-----------------------------------------------------------------------------------------------|
 | `Waiting`             | The disbursement is awaiting processing.                                                      |
-| `Delivered`           | Signifies successful delivery of the message to the recipient.                                |
+| `Delivered`           | Signifies successful provisioning of the data bundle to the recipient.                        |
 | `Uncertain`           | The delivery status is uncertain, possibly due to a lack of information from the gateway.     |
 | `Failed`              | Termination failed while attempting to handover to gateway                                    |
 | `InvalidMsisdn`       | The recipient's MSISDN (phone number) is invalid.                                             |

--- a/mobile-data/introduction.mdx
+++ b/mobile-data/introduction.mdx
@@ -6,27 +6,95 @@ The Mobile Data Disbursement API enables secure provisioning of mobile data bund
 This endpoint supports both bulk distribution scenarios and individualized allocations while maintaining the same
 authentication and access control used across all Belio API services.
 
+Optionally, you can include SMS notifications to recipients after their data bundle has been successfully disbursed.
+
 ## Prerequisites
 
 Before using this endpoint, ensure you have:
 
 - An active campaign for mobile data disbursement — available from the [Campaigns](https://cloud.belio.co.ke/mobile-data/campaigns)
-  page.
+page.
 - There are two ways to get a Campaign ID:
-  - Go to the [Campaigns](https://cloud.belio.co.ke/mobile-data/campaigns) page and copy the ID by clicking the copy icon on the
-    table as shown on the photo below.
-    ![CampaignTableImage](../images/campaigns-page.png)
-  - Call the [List Campaigns](/campaign/list) endpoint to retrieve all available campaigns and their IDs.
+- Go to the [Campaigns](https://cloud.belio.co.ke/mobile-data/campaigns) page and copy the ID by clicking the copy icon on the
+table as shown on the photo below.
+![CampaignTableImage](../images/campaigns-page.png)
+- Call the [List Campaigns](/campaign/list) endpoint to retrieve all available campaigns and their IDs.
 
 - API client authorization — Ensure your API Client includes permission to perform mobile data disbursement via `reward.mobile-data.disbursement`
-  authorization scope. These can be managed from the [API Clients](https://cloud.belio.co.ke/team-overview/api-access-keys) page.
+authorization scope. These can be managed from the [API Clients](https://cloud.belio.co.ke/team-overview/api-access-keys) page.
 
 ---
+
+
+## Optional SMS Notifications
+
+Messaging is optional. If `messaging` is omitted, the request disburses data only (no SMS).
+
+If messaging is used, SMS is sent after successful data disbursement and consumes SMS units independently of data units.
+
+### Messaging Configuration
+
+When `messaging` is provided, `messaging.serviceSelection` is required.
+
+- `DefaultService` — uses an auto-configured/default Belio's SMS service
+- `SelfService` — uses an explicitly provided SMS service ID (`serviceId`). View available services via [List Services](/service/list)
+or [Message Introduction](/message/introduction) .
+
+
+### SendToMany
+
+Use `SendToMany` to send the same `denomination` to multiple `phones`. You may include a single `messaging.message` (max **960** characters) to notify all recipients.
+
+```json
+{
+  "type": "SendToMany",
+  "phones": ["+254712345678", "+254701234567"],
+  "denomination": "1GB"
+}
+```
+
+```json
+{
+  "type": "SendToMany",
+  "phones": ["+254712345678", "+254701234567"],
+  "denomination": "1GB",
+  "messaging": {
+    "message": "Your 1GB bundle has been credited.",
+    "serviceSelection": { "type": "DefaultService" }
+  }
+}
+```
+
+### SendToEach
+
+Use `SendToEach` to send different `denomination` values per recipient. Each disbursement may include an optional `message`, and you can mix recipients with and without messages.
+
+If **any** disbursement includes a `message`, the top-level `messaging` configuration becomes mandatory. If no disbursement includes a message, `messaging` is optional and can be omitted.
+
+```json
+{
+  "type": "SendToEach",
+  "messaging": {
+    "serviceSelection": { "type": "SelfService", "serviceId": "svc_123" }
+  },
+  "disbursements": [
+    { "phone": "+254712345678", "denomination": "2GB", "message": "You’ve received 2GB data." },
+    { "phone": "+254701234567", "denomination": "500MB" }
+  ]
+}
+```
+- API client authorization — Ensure your API Client includes permission to perform SMS sending via `message.sms.send.oneway`
+authorization scope. These can be managed from the [API Clients](https://cloud.belio.co.ke/team-overview/api-access-keys) page.
+
+## Delivery Receipts
+
+You can include an optional `receiptRequest` to receive delivery receipts for data disbursement and (when messaging is used) SMS delivery status. Receipts may be delivered asynchronously and out of order.
 
 ## Optional Delivery Tracking
 
 You may include an optional `receiptRequest` object in the request body to receive webhook notifications when a disbursement
-attempt completes. This enables tracking of delivery outcomes per recipient.
+attempt completes. When messaging is enabled, receipts can also cover SMS delivery status. Receipts may be delivered
+asynchronously and out of order.
 
 The `receiptRequest` object includes:
 

--- a/mobile-data/send.mdx
+++ b/mobile-data/send.mdx
@@ -4,13 +4,23 @@ openapi: "POST /data/{campaignId}"
 ---
 
 <Note>
-  Refer to [Authentication](/authentication) for information on how to obtain a
-  Bearer token. This endpoint requires the `reward.mobile-data.disburse` API
-  client authorization scope to disburse mobile data. You can set up scopes on
-  the [API Clients](https://cloud.belio.co.ke/team-overview/api-access-keys)
-  page.
+    Refer to [Authentication](/authentication) for information on how to obtain a
+    Bearer token. This endpoint requires the `reward.mobile-data.disburse` API
+    client authorization scope to disburse mobile data. You can set up scopes on
+    the [API Clients](https://cloud.belio.co.ke/team-overview/api-access-keys)
+    page.
 </Note>
 
 ### Rate Limit
 
 This endpoint is rate limited to **400** disbursements per second.
+
+## Request Modes
+
+The API supports two request modes:
+
+- `SendToMany` — same data amount (and optional SMS message) sent to multiple recipients
+- `SendToEach` — individual data amounts and optional messages per recipient
+
+Both modes support a maximum of **100** recipients per request and the optional message is limited to not more than **960** characters .
+

--- a/openapi.json
+++ b/openapi.json
@@ -474,84 +474,112 @@
             "application/json": {
               "schema": {
                 "oneOf": [
-                  {
-                    "title": "SendToEach",
-                    "description": "Send a custom denomination to each recipient",
-                    "type": "object",
-                    "properties": {
-                      "type": {
-                        "type": "string",
-                        "enum": ["SendToEach"],
-                        "description": "Indicates per-recipient bundle disbursement mode"
-                      },
-                      "disbursements": {
-                        "type": "array",
-                        "minItems": 1,
-                        "items": {
-                          "type": "object",
-                          "properties": {
-                            "phone": {
-                              "type": "string",
-                              "description": "Recipient phone number"
-                            },
-                            "denomination": {
-                              "type": "string",
-                              "enum": [
-                                "10MB",
-                                "20MB",
-                                "25MB",
-                                "30MB",
-                                "50MB",
-                                "100MB",
-                                "150MB",
-                                "200MB",
-                                "250MB",
-                                "500MB",
-                                "750MB",
-                                "1GB",
-                                "2GB",
-                                "3GB",
-                                "5GB",
-                                "10GB"
-                              ],
-                              "description": "Bundle denomination to be sent to recipient. Should exist in the chosen campaign"
-                            }
-                          },
-                          "required": ["phone", "denomination"],
-                          "additionalProperties": false
-                        },
-                        "description": "List of recipients with individual denominations"
-                      },
-                      "receiptRequest": {
-                        "$ref": "#/components/schemas/DataReceiptRequest"
-                      }
-                    },
-                    "required": ["type", "disbursements"],
-                    "additionalProperties": false
-                  },
-                  {
-                    "title": "SendToMany",
-                    "description": "Send the same denomination to multiple recipients",
-                    "type": "object",
-                    "properties": {
-                      "type": {
-                        "type": "string",
-                        "enum": ["SendToMany"],
-                        "description": "Indicates bulk disbursement mode"
-                      },
-                      "phones": {
-                        "type": "array",
-                        "minItems": 1,
-                        "items": {
-                          "type": "string",
-                          "description": "Recipient phone number"
-                        },
-                        "description": "List of recipients' phone numbers e.g [712345678, 11234567, 712345678]. Cannot be empty"
-                      },
-                      "denomination": {
-                        "type": "string",
-                        "enum": [
-                          "10MB",
+	                  {
+	                    "title": "SendToEach",
+	                    "description": "Send a custom denomination to each recipient",
+	                    "type": "object",
+	                    "properties": {
+	                      "type": {
+	                        "type": "string",
+	                        "enum": ["SendToEach"],
+	                        "description": "Indicates per-recipient bundle disbursement mode"
+	                      },
+	                      "disbursements": {
+	                        "type": "array",
+	                        "minItems": 1,
+	                        "maxItems": 100,
+	                        "items": {
+	                          "type": "object",
+	                          "properties": {
+	                            "phone": {
+	                              "type": "string",
+	                              "description": "Recipient phone number"
+	                            },
+	                            "denomination": {
+	                              "type": "string",
+	                              "enum": [
+	                                "10MB",
+	                                "20MB",
+	                                "25MB",
+	                                "30MB",
+	                                "50MB",
+	                                "100MB",
+	                                "150MB",
+	                                "200MB",
+	                                "250MB",
+	                                "500MB",
+	                                "750MB",
+	                                "1GB",
+	                                "2GB",
+	                                "3GB",
+	                                "5GB",
+	                                "10GB"
+	                              ],
+	                              "description": "Bundle denomination to be sent to recipient. Should exist in the chosen campaign"
+	                            },
+	                            "message": {
+	                              "type": "string",
+	                              "minLength": 1,
+	                              "maxLength": 960,
+	                              "description": "Optional SMS notification sent after successful data disbursement (requires top-level messaging configuration)."
+	                            }
+	                          },
+	                          "required": ["phone", "denomination"],
+	                          "additionalProperties": false
+	                        },
+	                        "description": "List of recipients with individual denominations"
+	                      },
+	                      "messaging": {
+	                        "$ref": "#/components/schemas/DataMessagingConfig"
+	                      },
+	                      "receiptRequest": {
+	                        "$ref": "#/components/schemas/DataReceiptRequest"
+	                      }
+	                    },
+	                    "required": ["type", "disbursements"],
+	                    "allOf": [
+	                      {
+	                        "if": {
+	                          "properties": {
+	                            "disbursements": {
+	                              "contains": {
+	                                "type": "object",
+	                                "required": ["message"]
+	                              }
+	                            }
+	                          }
+	                        },
+	                        "then": {
+	                          "required": ["messaging"]
+	                        }
+	                      }
+	                    ],
+	                    "additionalProperties": false
+	                  },
+	                  {
+	                    "title": "SendToMany",
+	                    "description": "Send the same denomination to multiple recipients",
+	                    "type": "object",
+	                    "properties": {
+	                      "type": {
+	                        "type": "string",
+	                        "enum": ["SendToMany"],
+	                        "description": "Indicates bulk disbursement mode"
+	                      },
+	                      "phones": {
+	                        "type": "array",
+	                        "minItems": 1,
+	                        "maxItems": 100,
+	                        "items": {
+	                          "type": "string",
+	                          "description": "Recipient phone number"
+	                        },
+	                        "description": "List of recipients' phone numbers. Maximum of 100 per request."
+	                      },
+	                      "denomination": {
+	                        "type": "string",
+	                        "enum": [
+	                          "10MB",
                           "20MB",
                           "25MB",
                           "30MB",
@@ -567,16 +595,19 @@
                           "3GB",
                           "5GB",
                           "10GB"
-                        ],
-                        "description": "Bundle to be sent to recipient. Should exist in the chosen campaign."
-                      },
-                      "receiptRequest": {
-                        "$ref": "#/components/schemas/DataReceiptRequest"
-                      }
-                    },
-                    "required": ["type", "phones", "denomination"],
-                    "additionalProperties": false
-                  }
+	                        ],
+	                        "description": "Bundle to be sent to recipient. Should exist in the chosen campaign."
+	                      },
+	                      "messaging": {
+	                        "$ref": "#/components/schemas/DataMessagingToMany"
+	                      },
+	                      "receiptRequest": {
+	                        "$ref": "#/components/schemas/DataReceiptRequest"
+	                      }
+	                    },
+	                    "required": ["type", "phones", "denomination"],
+	                    "additionalProperties": false
+	                  }
                 ]
               }
             }
@@ -978,10 +1009,10 @@
           }
         }
       },
-      "CampaignFrequency": {
-        "type": "object",
-        "properties": {
-          "type": {
+	      "CampaignFrequency": {
+	        "type": "object",
+	        "properties": {
+	          "type": {
             "type": "string",
             "enum": [
               "OneTime",
@@ -997,12 +1028,75 @@
             ],
             "description": "Frequency type of the campaign"
           }
-        }
-      },
-      "DataReceiptRequest": {
-        "type": "object",
-        "description": "Receipt callback configuration",
-        "properties": {
+	        }
+	      },
+	      "MessagingServiceSelection": {
+	        "description": "Select which SMS service to use when messaging is enabled.",
+	        "oneOf": [
+	          {
+	            "title": "DefaultService",
+	            "type": "object",
+	            "properties": {
+	              "type": {
+	                "type": "string",
+	                "const": "DefaultService",
+	                "description": "Uses the campaign/product default SMS service"
+	              }
+	            },
+	            "required": ["type"],
+	            "additionalProperties": false
+	          },
+	          {
+	            "title": "SelfService",
+	            "type": "object",
+	            "properties": {
+	              "type": {
+	                "type": "string",
+	                "const": "SelfService",
+	                "description": "Uses an explicitly provided SMS service ID"
+	              },
+	              "serviceId": {
+	                "type": "string",
+	                "description": "Unique identifier of the SMS service to use"
+	              }
+	            },
+	            "required": ["type", "serviceId"],
+	            "additionalProperties": false
+	          }
+	        ]
+	      },
+	      "DataMessagingConfig": {
+	        "type": "object",
+	        "description": "Messaging configuration used when sending optional SMS notifications.",
+	        "properties": {
+	          "serviceSelection": {
+	            "$ref": "#/components/schemas/MessagingServiceSelection"
+	          }
+	        },
+	        "required": ["serviceSelection"],
+	        "additionalProperties": false
+	      },
+	      "DataMessagingToMany": {
+	        "type": "object",
+	        "description": "Optional SMS notification sent after successful data disbursement.",
+	        "properties": {
+	          "message": {
+	            "type": "string",
+	            "minLength": 1,
+	            "maxLength": 960,
+	            "description": "SMS content to be delivered to all recipients (SendToMany only)."
+	          },
+	          "serviceSelection": {
+	            "$ref": "#/components/schemas/MessagingServiceSelection"
+	          }
+	        },
+	        "required": ["message", "serviceSelection"],
+	        "additionalProperties": false
+	      },
+	      "DataReceiptRequest": {
+	        "type": "object",
+	        "description": "Receipt callback configuration",
+	        "properties": {
           "correlator": {
             "type": "string",
             "maxLength": 100,


### PR DESCRIPTION
## PR  SUMMARY

> This PR updates the Mobile Data Disbursement docs to support disbursing data bundles with or without SMS notifications. Messaging is optional and can be included to notify recipients after a successful data disbursement. Response structure remains unchanged.

#### What Changed

- Updated OpenAPI request schemas for SendToMany and SendToEach to include optional messaging support and enforce maxItems.

- Added messaging component schemas:

-  MessagingServiceSelection (DefaultService | SelfService)

- Documented request modes, messaging rules, and examples for both modes.

- **SendToMany**: optional single SMS message for all recipients; `messaging.serviceSelection` required if messaging provided.

- **SendToEach**: per-recipient optional message; if any disbursement includes message, top-level messaging is required.
receiptRequest remains optional and applies to the batch; may include data and SMS statuses (when messaging used).

-   Max 100 recipients per request in both modes.