### PR TITLE
ENG-1227-Extend-WhatsApp-API

### DIFF
--- a/messaging/whatsapp/delivery-receipt.mdx
+++ b/messaging/whatsapp/delivery-receipt.mdx
@@ -2,75 +2,124 @@
 title: "Delivery Receipts"
 ---
 
-Delivery receipts provide a mechanism to track the status of messages sent through the API.
-When you send a WhatsApp message with a `receiptRequest`, the system will send a delivery receipt to your specified callback
-URL once the message reaches its final state.
-This allows you to monitor the delivery status of your messages in real-time.
+Delivery receipts are callback events for WhatsApp messages sent through the API.
+When a request includes `receiptRequest`, the platform sends HTTP `POST` requests to the configured
+`callbackUrl` with `Content-Type: application/json`.
 
 <Note>
-  Delivery receipts are sent to the callback URL specified in the
-  `receiptRequest` object of the message request. If you do not include a
-  `receiptRequest`, no delivery receipt will be sent.
+  The callback body is a JSON object with a `type` discriminator. WhatsApp outbound status callbacks use
+  `WhatsAppOutboundMessageReceipt`.
 </Note>
 
 <Note>
-  Ensure that the callback URL is publicly accessible and can handle incoming
-  HTTP POST requests to receive the delivery receipts.
+  Ensure that the callback URL is publicly accessible and can handle unauthenticated HTTP POST requests.
 </Note>
 
-### Delivery Receipt Format
+### WhatsAppOutboundMessageReceipt
+
+Sent when the delivery status of a message you sent to a user changes. A single sent message can produce multiple
+callbacks in sequence: `Sent`, `Delivered`, then `Read` or `Played` for voice messages. A failed message produces a `Failed` callback.
+
+#### Example: Delivered
 
 ```json
 {
-  "type": "WhatsAppDeliveryReceipt",
-  "wamId": "wamid.HBgLMjU0NzAwMTExMjEzFQIAERgSM...",
+  "type": "WhatsAppOutboundMessageReceipt",
+  "wamId": "wamid.HBgLMTY1MDM4Nzk0MzkVAgASGBQzQUFERjg0NDEzNDdFODU3MUMxMAA=",
+  "correlator": "8f24c8c6-7e7c-4b6f-a622-d4a25f91d3c1",
   "phone": "+254700111213",
-  "timestamp": "2026-04-29T14:32:00+03:00",
+  "timestamp": "2025-05-11T10:31:13Z",
   "deliveryStatus": "Delivered",
-  "conversationId": "conv-abc123",
-  "pricingCategory": "Marketing",
-  "reason": "Internal error",
-  "reasonCode": "99"
+  "conversationId": "8f842dbba350821654c9dfed31f5635c",
+  "pricing": {
+    "type": "Regular",
+    "category": "Marketing"
+  }
 }
 ```
 
-| Field           | Type   | Always present | Description                                                              |
-| --------------- | ------ | -------------- | ------------------------------------------------------------------------ |
-| type            | string | Yes            | Always `WhatsAppDeliveryReceipt`                                         |
-| wamId           | string | Yes            | WhatsApp message ID assigned by Meta's servers                           |
-| phone           | string | Yes            | Recipient phone number in E.164 format                                   |
-| timestamp       | string | Yes            | ISO 8601 datetime of the status event                                    |
-| deliveryStatus  | string | Yes            | Current delivery state.                                                  |
-| conversationId  | string | No             | Meta conversation ID; present once a conversation window is opened       |
-| pricingCategory | string | No             | Pricing category applied to this message.                                |
-| reason          | string | No             | Human-readable failure reason; present when `deliveryStatus` is `Failed` |
-| reasonCode      | string | No             | Machine-readable error code; present when `deliveryStatus` is `Failed`   |
+#### Example: Failed
 
-### Delivery Statuses
+```json
+{
+  "type": "WhatsAppOutboundMessageReceipt",
+  "wamId": "wamid.HBgLMTY1MDM4Nzk0MzkVAgARGBI0QUQ2MjA4NEYyRkExNjMyREUA",
+  "correlator": "8f24c8c6-7e7c-4b6f-a622-d4a25f91d3c1",
+  "phone": "254700111213",
+  "timestamp": "2025-05-11T10:35:00Z",
+  "deliveryStatus": "Failed",
+  "reason": "This message was not delivered to maintain healthy ecosystem engagement.",
+  "reasonCode": "131049"
+}
+```
 
-| Value     | WhatsApp UI equivalent | Description                                                                                |
-| --------- | ---------------------- | ------------------------------------------------------------------------------------------ |
-| Waiting   | Clock                  | Message is queued and waiting to be sent to the recipient's device (default initial state) |
-| Sent      | Single checkmark       | Message was sent from WhatsApp servers to the recipient                                    |
-| Delivered | Two checkmarks         | Message was successfully delivered to the recipient's device                               |
-| Read      | Two blue checkmarks    | Message was displayed in an open chat thread on the recipient's device                     |
-| Failed    | Red error triangle     | Message could not be delivered to the recipient's device                                   |
-| Played    | Blue microphone        | Voice message was played for the first time on the recipient's device                      |
+### Fields
 
-### Pricing Categories
+| Field            | Type   | Always present | Description                                                                                                                                                                   |
+|------------------|--------|----------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `type`           | string | Yes            | Always `WhatsAppOutboundMessageReceipt`                                                                                                                                       |
+| `wamId`          | string | No             | WhatsApp message ID assigned by Meta. May be omitted for `Failed` when termination to Meta was not successful.                                                                |
+| `correlator`     | string | Yes            | Unique ID that correlates with your original message request.                                                                                                                 |
+| `phone`          | string | Yes            | Recipient phone number in E.164 format with the leading `+`.                                                                                                                  |
+| `timestamp`      | string | Yes            | ISO 8601 timestamp for when the status event occurred, in UTC.                                                                                                                |
+| `deliveryStatus` | string | Yes            | Current delivery state. See [Delivery Status](#delivery-status-values) values.                                                                                                |
+| `conversationId` | string | No             | WhatsApp conversation window ID. Present with `Sent` and with one of either `Delivered` or `Read`. Omitted unless the conversation used a free entry point.                   |
+| `pricing`        | object | No             | [Pricing type](#pricing-type-values) and [category](#pricing-category-values). Present on `Sent` and on one of either `Delivered` or `Read`, not both, and never on `Failed`. |
+| `reason`         | string | No             | Human-readable error description. Only present when `deliveryStatus` is `Failed`.                                                                                             |
+| `reasonCode`     | string | No             | Numeric error code as a string. Only present when `deliveryStatus` is `Failed`.                                                                                               |
 
-WhatsApp Business charges per conversation, categorized by the nature of the message. The `pricingCategory` field in
-delivery receipts and the `units` map in the send response both use these values.
+### Delivery Status Values
 
-| Value                       | Description                                                                                                      |
-| --------------------------- | ---------------------------------------------------------------------------------------------------------------- |
-| Authentication              | Sent as part of an authentication flow (e.g. OTP). Authentication rate applies                                   |
-| AuthenticationInternational | Authentication message sent to an international (non-domestic) number. International authentication rate applies |
-| Marketing                   | Promotional or marketing content. Marketing rate applies                                                         |
-| MarketingLite               | Sent via the Marketing Messages API (lighter marketing tier). Marketing Messages API rate applies                |
-| ReferralConversation        | Conversation initiated through a free entry point (e.g. Click-to-WhatsApp ad). No charge applies                 |
-| Service                     | Sent in response to a user-initiated message within the 24-hour service window. Service rate applies             |
-| Utility                     | Transactional or account-related notifications (e.g. order confirmations). Utility rate applies                  |
+| Value       | WhatsApp UI         | Meaning                                                                        |
+|-------------|---------------------|--------------------------------------------------------------------------------|
+| `Waiting`   | Clock icon          | Message is being processed and has not yet been sent to the recipient's device |
+| `Sent`      | Single checkmark    | Message sent from Meta's servers to the recipient                              |
+| `Delivered` | Two checkmarks      | Message delivered to the recipient's device                                    |
+| `Read`      | Two blue checkmarks | Message displayed in an open chat on the recipient's device                    |
+| `Played`    | Blue microphone     | Voice message played by the recipient                                          |
+| `Failed`    | Red error triangle  | Message could not be sent or delivered                                         |
+| `Uncertain` | -                   | Delivery outcome is unknown; the message may or may not have been delivered    |
+
+### Pricing Type Values
+
+| Value                 | Description                                                                                                                     |
+|-----------------------|---------------------------------------------------------------------------------------------------------------------------------|
+| `Regular`             | Message is billable.                                                                                                            |
+| `FreeCustomerService` | Message is free because it was either a utility template message or non-template message sent within a customer service window. |
+| `FreeEntryPoint`      | Message is free because it was sent within an open free entry point window.                                                     |
+
+### Pricing Category Values
+
+| Value                         | Description                                         |
+|-------------------------------|-----------------------------------------------------|
+| `Authentication`              | Authentication message                              |
+| `AuthenticationInternational` | Authentication message billed at international rate |
+| `Marketing`                   | Marketing message                                   |
+| `MarketingLite`               | Marketing Messages API message                      |
+| `ReferralConversation`        | Free entry point conversation                       |
+| `Service`                     | Service message                                     |
+| `Utility`                     | Utility message                                     |
+
+### Callback Sequence
+
+A successfully delivered message produces sequential `WhatsAppOutboundMessageReceipt` callbacks:
+
+```text
+POST /your-callback  ->  deliveryStatus: "Sent"       (pricing present)
+POST /your-callback  ->  deliveryStatus: "Delivered"  (pricing may be present)
+POST /your-callback  ->  deliveryStatus: "Read"       (pricing present if not already sent with "Delivered")
+```
+
+A failed message produces a single callback:
+
+```text
+POST /your-callback  ->  deliveryStatus: "Failed"     (reason and reasonCode present)
+```
+
+<Note>
+    If a message is delivered and read at the same time, for example when the recipient has the chat open,
+    the `Delivered` callback is skipped and only `Read` is sent.
+</Note>
 
 ### Receipt Request
 
@@ -84,13 +133,13 @@ It must be included in the WhatsApp message request body when sending a message 
 }
 ```
 
-| Field       | Type   | Constraints                                                                                                      |
-| ----------- | ------ | ---------------------------------------------------------------------------------------------------------------- |
-| correlator  | string | Non-empty, maximum 100 characters. Used to correlate callbacks to the originating request (we recommend `UUID`). |
-| callbackUrl | string | Valid `https://` or `http://` URL. The endpoint must not require authentication                                  |
+| Field         | Type   | Constraints                                                                                                     |
+|---------------|--------|-----------------------------------------------------------------------------------------------------------------|
+| `correlator`  | string | Non-empty, maximum 100 characters. Used to correlate callbacks to the originating request. Recommended: `UUID`. |
+| `callbackUrl` | string | Valid `https://` or `http://` URL. The endpoint must not require authentication.                                |
 
 <Warning>
-  When provided, **both fields are required**. An invalid `receiptRequest`
+  When provided, both fields are required. An invalid `receiptRequest`
   causes the entire request to be rejected with `400 Bad Request` before any
   messages are dispatched.
 </Warning>

--- a/messaging/whatsapp/introduction.mdx
+++ b/messaging/whatsapp/introduction.mdx
@@ -19,7 +19,7 @@ to create a service.
 This includes having a verified phone number and a display name that adheres to WhatsApp's guidelines.
 3. **Approved Message Templates**: You need to create and get approval for message templates that you intend to use for sending messages.
 These templates must comply with WhatsApp's policies and guidelines. Check [WhatsApp Business Messaging policy](https://whatsappbusiness.com/policy/).
-4. **API client authorization**: This endpoint requires the `message.whatsapp.send.oneway` API client authorization scope to send one way
+4. **API client authorization**: This endpoint requires the `message.whatsapp.send` API client authorization scope to send
 WhatsApp messages. You can set up scopes on the [API Clients](https://cloud.belio.co.ke/team-overview/api-access-keys) page.
 
 ## Advanced Features

--- a/messaging/whatsapp/send.mdx
+++ b/messaging/whatsapp/send.mdx
@@ -6,8 +6,7 @@ openapi: "POST /message/{serviceId}/whatsapp"
 <Note>
     Refer to [Authentication](/authentication) for information on how to obtain a bearer token.
 
-    This endpoint requires the `message.whatsapp.send.oneway` API client authorization scope to send one-way WhatsApp
-    messages.
+    This endpoint requires the `message.whatsapp.send` API client authorization scope to send WhatsApp messages.
 
     You can configure scopes on the [API Clients](https://cloud.belio.co.ke/team-overview/api-access-keys) page.
 </Note>
@@ -16,14 +15,14 @@ openapi: "POST /message/{serviceId}/whatsapp"
 
 The API supports two request modes:
 
-- `TemplateSendToMany` — Sends the same template message with shared parameters to multiple recipients.
-- `TemplateSendToEach` — Sends personalized template messages to individual recipients. Parameters can differ per recipient.
+- `TemplateSendToMany` - Sends the same template message with shared parameters to multiple recipients.
+- `TemplateSendToEach` - Sends personalized template messages to individual recipients. Parameters can differ per recipient.
 
 ---
 
 ### Template Parameters
 
-Templates support dynamic parameters that are substituted into the template body or header when messages are sent.
+Templates support dynamic parameters that are substituted into the template body, header, buttons, OTP, offers, carousel cards, media, and location components when messages are sent.
 
 #### Parameter Types
 

--- a/messaging/whatsapp/templates/introduction.mdx
+++ b/messaging/whatsapp/templates/introduction.mdx
@@ -54,7 +54,10 @@ Example: `{ "type": "BodyPositionalParameter", "position": 1, "value": "Alice" }
 Parameters can be applied to:
 
 * Body content
-* Header content (text or media)
+* Header content (text, media, or location)
+* URL, copy, quick reply, voice call, OTP, and coupon buttons
+* Limited-time offers
+* Carousel cards
 
 ---
 

--- a/openapi.json
+++ b/openapi.json
@@ -678,6 +678,268 @@
         }
       }
     },
+    "/message/{serviceId}/whatsapp": {
+      "post": {
+        "operationId": "sendWhatsAppMessage",
+        "tags": [
+          "Whatsapp"
+        ],
+        "description": "Sends a WhatsApp template message to one or more recipients via a configured WhatsApp Business Account (WABA). Only approved template messages are supported.",
+        "parameters": [
+          {
+            "name": "serviceId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Unique identifier of the WhatsApp service"
+          }
+        ],
+        "requestBody": {
+          "description": "WhatsApp template message send request",
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "title": "TemplateSendToMany",
+                    "type": "object",
+                    "properties": {
+                      "type": {
+                        "type": "string",
+                        "enum": [
+                          "TemplateSendToMany"
+                        ],
+                        "description": "Must be \"TemplateSendToMany\""
+                      },
+                      "phoneNumberId": {
+                        "type": "string",
+                        "description": "Phone number ID of the WABA sender. Must match a number registered on the service"
+                      },
+                      "templateId": {
+                        "type": "string",
+                        "description": "ID of the approved WhatsApp template to send"
+                      },
+                      "addresses": {
+                        "type": "array",
+                        "maxItems": 10,
+                        "items": {
+                          "type": "string"
+                        },
+                        "description": "Recipient phone numbers. Maximum 10 per request"
+                      },
+                      "params": {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/components/schemas/TemplateParameter"
+                        }
+                      },
+                      "receiptRequest": {
+                        "type": "object",
+                        "description": "Delivery receipt callback configuration. When provided, both fields are required.",
+                        "properties": {
+                          "correlator": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 100
+                          },
+                          "callbackUrl": {
+                            "type": "string",
+                            "format": "uri"
+                          }
+                        },
+                        "required": [
+                          "correlator",
+                          "callbackUrl"
+                        ],
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": [
+                      "type",
+                      "phoneNumberId",
+                      "templateId",
+                      "addresses",
+                      "params"
+                    ],
+                    "additionalProperties": false
+                  },
+                  {
+                    "title": "TemplateSendToEach",
+                    "type": "object",
+                    "properties": {
+                      "type": {
+                        "type": "string",
+                        "enum": [
+                          "TemplateSendToEach"
+                        ],
+                        "description": "Must be \"TemplateSendToEach\""
+                      },
+                      "phoneNumberId": {
+                        "type": "string",
+                        "description": "Phone number ID of the WABA sender. Must match a number registered on the service"
+                      },
+                      "templateId": {
+                        "type": "string",
+                        "description": "ID of the approved WhatsApp template to send"
+                      },
+                      "messages": {
+                        "type": "array",
+                        "maxItems": 10,
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "phone": {
+                              "type": "string",
+                              "description": "Recipient phone number"
+                            },
+                            "params": {
+                              "type": "array",
+                              "items": {
+                                "$ref": "#/components/schemas/TemplateParameter"
+                              }
+                            }
+                          },
+                          "required": [
+                            "phone",
+                            "params"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "description": "Per-recipient message objects. Maximum 10 per request"
+                      },
+                      "receiptRequest": {
+                        "type": "object",
+                        "description": "Delivery receipt callback configuration. When provided, both fields are required.",
+                        "properties": {
+                          "correlator": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 100
+                          },
+                          "callbackUrl": {
+                            "type": "string",
+                            "format": "uri"
+                          }
+                        },
+                        "required": [
+                          "correlator",
+                          "callbackUrl"
+                        ],
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": [
+                      "type",
+                      "phoneNumberId",
+                      "templateId",
+                      "messages"
+                    ],
+                    "additionalProperties": false
+                  }
+                ]
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful send request accepted and queued",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "result": {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "WhatsAppResponse"
+                          ]
+                        },
+                        "requestId": {
+                          "type": "string",
+                          "format": "uuid"
+                        },
+                        "addresses": {
+                          "type": "integer"
+                        },
+                        "units": {
+                          "type": "object",
+                          "description": "Credit units consumed per Pricing Category. Currently always {}."
+                        }
+                      },
+                      "required": [
+                        "type",
+                        "requestId",
+                        "addresses",
+                        "units"
+                      ],
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "result"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request - invalid input parameters or template parameter validation failure",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/APIError"
+                    },
+                    {
+                      "$ref": "#/components/schemas/TemplateParameterValidationFailure"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthenticated - invalid credentials",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found - service, phone number ID, or template not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/data/campaign": {
       "get": {
         "operationId": "listCampaigns",
@@ -1679,6 +1941,9 @@
         "properties": {
           "desc": {
             "type": "string"
+          },
+          "result": {
+            "description": "Optional structured error details."
           }
         }
       },
@@ -1686,12 +1951,21 @@
         "type": "string",
         "description": "Current WhatsApp delivery state.",
         "enum": [
-          "Waiting",
           "Sent",
           "Delivered",
           "Read",
           "Failed",
-          "Played"
+          "Played",
+          "Uncertain"
+        ]
+      },
+      "WhatsAppPricingType": {
+        "type": "string",
+        "description": "WhatsApp billing type applied to this message.",
+        "enum": [
+          "Regular",
+          "FreeCustomerService",
+          "FreeEntryPoint"
         ]
       },
       "WhatsAppPricingCategory": {
@@ -1706,6 +1980,72 @@
           "Service",
           "Utility"
         ]
+      },
+      "WhatsAppPricing": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "$ref": "#/components/schemas/WhatsAppPricingType"
+          },
+          "category": {
+            "$ref": "#/components/schemas/WhatsAppPricingCategory"
+          }
+        },
+        "required": [
+          "type",
+          "category"
+        ],
+        "additionalProperties": false
+      },
+      "TemplateParameter": {
+        "description": "Tagged template parameter used to fill body, header, button, OTP, offer, carousel, media, or location placeholders.",
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/NamedTemplateParameter"
+          },
+          {
+            "$ref": "#/components/schemas/PositionalTemplateParameter"
+          },
+          {
+            "$ref": "#/components/schemas/MediaTemplateParameter"
+          },
+          {
+            "$ref": "#/components/schemas/LocationTemplateParameter"
+          },
+          {
+            "$ref": "#/components/schemas/CopyParameter"
+          },
+          {
+            "$ref": "#/components/schemas/TimeToLiveParameter"
+          },
+          {
+            "$ref": "#/components/schemas/VoiceCallPayloadParameter"
+          },
+          {
+            "$ref": "#/components/schemas/OtpParameter"
+          },
+          {
+            "$ref": "#/components/schemas/UrlNamedParameter"
+          },
+          {
+            "$ref": "#/components/schemas/UrlPositionalParameter"
+          },
+          {
+            "$ref": "#/components/schemas/CouponCodeParameter"
+          },
+          {
+            "$ref": "#/components/schemas/QuickReplyPayloadParameter"
+          },
+          {
+            "$ref": "#/components/schemas/LimitedTimeOfferParameter"
+          },
+          {
+            "$ref": "#/components/schemas/CarouselCardParameter"
+          }
+        ],
+        "discriminator": {
+          "propertyName": "type"
+        }
       },
       "PositionalTemplateParameter": {
         "type": "object",
@@ -1723,10 +2063,13 @@
             ]
           },
           "position": {
-            "type": "integer"
+            "type": "integer",
+            "minimum": 1
           },
           "value": {
-            "type": "string"
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 1024
           }
         },
         "additionalProperties": false
@@ -1747,45 +2090,415 @@
             ]
           },
           "name": {
-            "type": "string"
+            "type": "string",
+            "minLength": 1
           },
           "value": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 1024
+          }
+        },
+        "additionalProperties": false
+      },
+      "MediaTemplateParameter": {
+        "type": "object",
+        "required": [
+          "type",
+          "url"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "MediaTemplateParameter"
+          },
+          "url": {
+            "type": "string",
+            "format": "uri",
+            "minLength": 1,
+            "description": "Public media URL for an image, video, or document header."
+          },
+          "filename": {
+            "type": "string",
+            "description": "Optional filename for document media."
+          }
+        },
+        "additionalProperties": false
+      },
+      "LocationTemplateParameter": {
+        "type": "object",
+        "required": [
+          "type",
+          "latitude",
+          "longitude"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "LocationTemplateParameter"
+          },
+          "latitude": {
+            "type": "number",
+            "minimum": -90,
+            "maximum": 90
+          },
+          "longitude": {
+            "type": "number",
+            "minimum": -180,
+            "maximum": 180
+          },
+          "name": {
+            "type": "string"
+          },
+          "address": {
             "type": "string"
           }
         },
         "additionalProperties": false
       },
-      "WhatsAppDeliveryReceipt": {
+      "CopyParameter": {
+        "type": "object",
+        "required": [
+          "type",
+          "value"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "CopyParameter"
+          },
+          "value": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "additionalProperties": false
+      },
+      "TimeToLiveParameter": {
+        "type": "object",
+        "required": [
+          "type",
+          "minutes"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "TimeToLiveParameter"
+          },
+          "minutes": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "Time-to-live duration in minutes. The accepted range depends on the template configuration."
+          }
+        },
+        "additionalProperties": false
+      },
+      "VoiceCallPayloadParameter": {
+        "type": "object",
+        "required": [
+          "type",
+          "payload"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "VoiceCallPayloadParameter"
+          },
+          "payload": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "additionalProperties": false
+      },
+      "OtpParameter": {
+        "type": "object",
+        "required": [
+          "type",
+          "code"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "OtpParameter"
+          },
+          "code": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "additionalProperties": false
+      },
+      "UrlNamedParameter": {
+        "type": "object",
+        "required": [
+          "type",
+          "name",
+          "value"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "UrlNamedParameter"
+          },
+          "name": {
+            "type": "string",
+            "minLength": 1
+          },
+          "value": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "additionalProperties": false
+      },
+      "UrlPositionalParameter": {
+        "type": "object",
+        "required": [
+          "type",
+          "position",
+          "value"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "UrlPositionalParameter"
+          },
+          "position": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "value": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "additionalProperties": false
+      },
+      "CouponCodeParameter": {
+        "type": "object",
+        "required": [
+          "type",
+          "code"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "CouponCodeParameter"
+          },
+          "code": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "additionalProperties": false
+      },
+      "QuickReplyPayloadParameter": {
+        "type": "object",
+        "required": [
+          "type",
+          "payload"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "QuickReplyPayloadParameter"
+          },
+          "payload": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "additionalProperties": false
+      },
+      "LimitedTimeOfferParameter": {
+        "type": "object",
+        "required": [
+          "type",
+          "expiresAt"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "LimitedTimeOfferParameter"
+          },
+          "expiresAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Offer expiry timestamp. Must be in the future."
+          }
+        },
+        "additionalProperties": false
+      },
+      "CarouselCardParameter": {
+        "type": "object",
+        "required": [
+          "type",
+          "cardIndex",
+          "params"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "CarouselCardParameter"
+          },
+          "cardIndex": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "params": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TemplateParameter"
+            }
+          }
+        },
+        "additionalProperties": false
+      },
+      "TemplateValidationError": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/TemplateParameterError"
+          },
+          {
+            "$ref": "#/components/schemas/TemplateComponentError"
+          }
+        ],
+        "discriminator": {
+          "propertyName": "type"
+        }
+      },
+      "TemplateParameterError": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "ParameterError"
+          },
+          "parameterType": {
+            "type": "string"
+          },
+          "error": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "parameterType",
+          "error"
+        ],
+        "additionalProperties": false
+      },
+      "TemplateComponentError": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "ComponentError"
+          },
+          "componentType": {
+            "type": "string"
+          },
+          "error": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "componentType",
+          "error"
+        ],
+        "additionalProperties": false
+      },
+      "TemplateSendToManyValidationResult": {
+        "type": "object",
+        "properties": {
+          "errors": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TemplateValidationError"
+            }
+          }
+        },
+        "required": [
+          "errors"
+        ],
+        "additionalProperties": false
+      },
+      "TemplateSendToEachValidationResult": {
+        "type": "object",
+        "description": "Validation errors keyed by recipient phone number. Only recipients with failures are included.",
+        "not": {
+          "required": [
+            "errors"
+          ]
+        },
+        "additionalProperties": {
+          "type": "array",
+          "items": {
+            "$ref": "#/components/schemas/TemplateValidationError"
+          }
+        }
+      },
+      "TemplateParameterValidationFailure": {
+        "type": "object",
+        "properties": {
+          "desc": {
+            "type": "string",
+            "const": "Template parameter validation failed"
+          },
+          "result": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/TemplateSendToManyValidationResult"
+              },
+              {
+                "$ref": "#/components/schemas/TemplateSendToEachValidationResult"
+              }
+            ]
+          }
+        },
+        "required": [
+          "desc",
+          "result"
+        ],
+        "additionalProperties": false
+      },
+      "WhatsAppOutboundMessageReceipt": {
         "type": "object",
         "description": "Callback payload posted to the receiptRequest.callbackUrl when a message delivery status changes.",
         "properties": {
           "type": {
             "type": "string",
-            "const": "WhatsAppDeliveryReceipt",
-            "description": "Always \"WhatsAppDeliveryReceipt\""
+            "const": "WhatsAppOutboundMessageReceipt",
+            "description": "Always \"WhatsAppOutboundMessageReceipt\""
           },
           "wamId": {
             "type": "string",
-            "description": "WhatsApp message ID assigned by Meta's servers"
+            "description": "WhatsApp message ID assigned by Meta. May be omitted when deliveryStatus is Failed and termination to Meta was not successful."
+          },
+          "correlator": {
+            "type": "string",
+            "description": "Unique ID that correlates with the original message request."
           },
           "phone": {
             "type": "string",
-            "description": "Recipient phone number in E.164 format"
+            "description": "Recipient phone number in E.164 format without the leading +."
           },
           "timestamp": {
             "type": "string",
             "format": "date-time",
-            "description": "ISO 8601 datetime of the status event"
+            "description": "When the status event occurred in UTC."
           },
           "deliveryStatus": {
             "$ref": "#/components/schemas/WhatsAppDeliveryStatus"
           },
           "conversationId": {
             "type": "string",
-            "description": "Meta conversation ID; present once a conversation window is opened"
+            "description": "WhatsApp conversation window ID. Present only for selected non-failed status callbacks."
           },
-          "pricingCategory": {
-            "$ref": "#/components/schemas/WhatsAppPricingCategory"
+          "pricing": {
+            "$ref": "#/components/schemas/WhatsAppPricing"
           },
           "reason": {
             "type": "string",
@@ -1798,7 +2511,7 @@
         },
         "required": [
           "type",
-          "wamId",
+          "correlator",
           "phone",
           "timestamp",
           "deliveryStatus"


### PR DESCRIPTION
# ENG-1227: Extend WhatsApp API

## Description

This PR extends and refines the WhatsApp API documentation and OpenAPI specification to provide comprehensive coverage of message sending, delivery receipt handling, and template parameter functionality.

## Changes

### 1. **API Scope Updates**
- Updated WhatsApp API authorization scope from `message.whatsapp.send.oneway` to `message.whatsapp.send` across all documentation files and OpenAPI spec
- This reflects the platform's shift from one-way messaging to bidirectional communication support
- **Files affected:**
  - `messaging/introduction.mdx`
  - `messaging/whatsapp/introduction.mdx`
  - `messaging/whatsapp/send.mdx`
  - `openapi.json`

### 2. **Delivery Receipt Documentation Overhaul** (`messaging/whatsapp/delivery-receipt.mdx`)
- Restructured delivery receipt documentation with clearer callback mechanism explanation
- Renamed callback type from `WhatsAppDeliveryReceipt` to `WhatsAppOutboundMessageReceipt` for clarity
- **New delivery status**: Added `Uncertain` state to handle edge cases where delivery outcome is unknown
- **Pricing information**:
  - Introduced `WhatsAppPricingType` enum with values: `Regular`, `FreeCustomerService`, `FreeEntryPoint`
  - Replaced single `pricingCategory` field with structured `pricing` object containing both `type` and `category`
  - Updated pricing category documentation with all supported values

- **Field changes**:
  - Added `correlator` field (required) for message request correlation
  - Made `wamId` optional (may be omitted for failed messages)
  - Updated `phone` field description (E.164 format without leading `+`)
  - Updated `timestamp` description (now explicitly UTC)
  - Made `conversationId` optional with clearer presence conditions

- **Callback sequence**: Added detailed callback flow documentation showing sequential callbacks for successful vs. failed deliveries

### 3. **Extended Template Parameter Support** (`messaging/whatsapp/send.mdx` & `openapi.json`)
- Updated template parameter documentation to explicitly list all supported placeholder types:
  - Body content
  - Header content (text, media, or location)
  - **New**: URL, copy, quick reply, voice call, OTP, and coupon buttons
  - **New**: Limited-time offers
  - **New**: Carousel cards

- **OpenAPI Schema Enhancements**:
  - Added comprehensive `POST /message/{serviceId}/whatsapp` endpoint specification
  - Introduced `TemplateSendToMany` request type (batch send with shared parameters to up to 10 recipients)
  - Introduced `TemplateSendToEach` request type (personalized send with per-recipient parameters)
  - Added 13 new template parameter types with full schema definitions:
    - `MediaTemplateParameter` (image, video, document)
    - `LocationTemplateParameter` (latitude, longitude, name, address)
    - `CopyParameter` (button copy text)
    - `TimeToLiveParameter` (offer expiration)
    - `VoiceCallPayloadParameter`
    - `OtpParameter`
    - `UrlNamedParameter` / `UrlPositionalParameter`
    - `CouponCodeParameter`
    - `QuickReplyPayloadParameter`
    - `LimitedTimeOfferParameter`
    - `CarouselCardParameter`

  - Added validation error types:
    - `TemplateParameterError` (parameter-level errors)
    - `TemplateComponentError` (component-level errors)
    - `TemplateSendToManyValidationResult`
    - `TemplateSendToEachValidationResult`
    - `TemplateParameterValidationFailure` (400 response schema)

  - Enhanced parameter constraints:
    - Positional/Named parameters: min length 1, max 1024 characters
    - Position index minimum: 1
    - Added proper validation patterns for all parameter types

### 4. **Template Introduction Updates** (`messaging/whatsapp/templates/introduction.mdx`)
- Updated parameter application documentation to list newly supported components:
  - Buttons (URL, copy, quick reply, voice call, OTP, coupon)
  - Limited-time offers
  - Carousel cards

