### PR TITLE
ENG-1252 Update WhatsApp outbound receipt fields

### DIFF
--- a/messaging/whatsapp/delivery-receipt.mdx
+++ b/messaging/whatsapp/delivery-receipt.mdx
@@ -7,12 +7,13 @@ When a request includes `receiptRequest`, the platform sends HTTP `POST` request
 `callbackUrl` with `Content-Type: application/json`.
 
 <Note>
-  The callback body is a JSON object with a `type` discriminator. WhatsApp outbound status callbacks use
-  `WhatsAppOutboundMessageReceipt`.
+  The callback body is a JSON object with a `type` discriminator. WhatsApp
+  outbound status callbacks use `WhatsAppOutboundMessageReceipt`.
 </Note>
 
 <Note>
-  Ensure that the callback URL is publicly accessible and can handle unauthenticated HTTP POST requests.
+  Ensure that the callback URL is publicly accessible and can handle
+  unauthenticated HTTP POST requests.
 </Note>
 
 ### WhatsAppOutboundMessageReceipt
@@ -25,9 +26,12 @@ callbacks in sequence: `Sent`, `Delivered`, then `Read` or `Played` for voice me
 ```json
 {
   "type": "WhatsAppOutboundMessageReceipt",
+  "wabaId": "102290129340398",
+  "phoneNumberId": "106540352242922",
   "wamId": "wamid.HBgLMTY1MDM4Nzk0MzkVAgASGBQzQUFERjg0NDEzNDdFODU3MUMxMAA=",
   "correlator": "8f24c8c6-7e7c-4b6f-a622-d4a25f91d3c1",
-  "phone": "+254700111213",
+  "sender": "15550783881",
+  "recipient": "254700111213",
   "timestamp": "2025-05-11T10:31:13Z",
   "deliveryStatus": "Delivered",
   "conversationId": "8f842dbba350821654c9dfed31f5635c",
@@ -43,9 +47,12 @@ callbacks in sequence: `Sent`, `Delivered`, then `Read` or `Played` for voice me
 ```json
 {
   "type": "WhatsAppOutboundMessageReceipt",
+  "wabaId": "102290129340398",
+  "phoneNumberId": "106540352242922",
   "wamId": "wamid.HBgLMTY1MDM4Nzk0MzkVAgARGBI0QUQ2MjA4NEYyRkExNjMyREUA",
   "correlator": "8f24c8c6-7e7c-4b6f-a622-d4a25f91d3c1",
-  "phone": "254700111213",
+  "sender": "15550783881",
+  "recipient": "254700111213",
   "timestamp": "2025-05-11T10:35:00Z",
   "deliveryStatus": "Failed",
   "reason": "This message was not delivered to maintain healthy ecosystem engagement.",
@@ -56,11 +63,14 @@ callbacks in sequence: `Sent`, `Delivered`, then `Read` or `Played` for voice me
 ### Fields
 
 | Field            | Type   | Always present | Description                                                                                                                                                                   |
-|------------------|--------|----------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ---------------- | ------ | -------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `type`           | string | Yes            | Always `WhatsAppOutboundMessageReceipt`                                                                                                                                       |
+| `wabaId`         | string | Yes            | Your WhatsApp Business Account ID.                                                                                                                                            |
+| `phoneNumberId`  | string | Yes            | WhatsApp Business Account Phone Number ID through which the message was sent.                                                                                                 |
 | `wamId`          | string | No             | WhatsApp message ID assigned by Meta. May be omitted for `Failed` when termination to Meta was not successful.                                                                |
 | `correlator`     | string | Yes            | Unique ID that correlates with your original message request.                                                                                                                 |
-| `phone`          | string | Yes            | Recipient phone number in E.164 format with the leading `+`.                                                                                                                  |
+| `sender`         | string | Yes            | Sender phone number (Business).                                                                                                                                               |
+| `recipient`      | string | Yes            | Recipient phone number (User).                                                                                                                                                |
 | `timestamp`      | string | Yes            | ISO 8601 timestamp for when the status event occurred, in UTC.                                                                                                                |
 | `deliveryStatus` | string | Yes            | Current delivery state. See [Delivery Status](#delivery-status-values) values.                                                                                                |
 | `conversationId` | string | No             | WhatsApp conversation window ID. Present with `Sent` and with one of either `Delivered` or `Read`. Omitted unless the conversation used a free entry point.                   |
@@ -71,7 +81,7 @@ callbacks in sequence: `Sent`, `Delivered`, then `Read` or `Played` for voice me
 ### Delivery Status Values
 
 | Value       | WhatsApp UI         | Meaning                                                                        |
-|-------------|---------------------|--------------------------------------------------------------------------------|
+| ----------- | ------------------- | ------------------------------------------------------------------------------ |
 | `Waiting`   | Clock icon          | Message is being processed and has not yet been sent to the recipient's device |
 | `Sent`      | Single checkmark    | Message sent from Meta's servers to the recipient                              |
 | `Delivered` | Two checkmarks      | Message delivered to the recipient's device                                    |
@@ -83,7 +93,7 @@ callbacks in sequence: `Sent`, `Delivered`, then `Read` or `Played` for voice me
 ### Pricing Type Values
 
 | Value                 | Description                                                                                                                     |
-|-----------------------|---------------------------------------------------------------------------------------------------------------------------------|
+| --------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
 | `Regular`             | Message is billable.                                                                                                            |
 | `FreeCustomerService` | Message is free because it was either a utility template message or non-template message sent within a customer service window. |
 | `FreeEntryPoint`      | Message is free because it was sent within an open free entry point window.                                                     |
@@ -91,7 +101,7 @@ callbacks in sequence: `Sent`, `Delivered`, then `Read` or `Played` for voice me
 ### Pricing Category Values
 
 | Value                         | Description                                         |
-|-------------------------------|-----------------------------------------------------|
+| ----------------------------- | --------------------------------------------------- |
 | `Authentication`              | Authentication message                              |
 | `AuthenticationInternational` | Authentication message billed at international rate |
 | `Marketing`                   | Marketing message                                   |
@@ -117,8 +127,9 @@ POST /your-callback  ->  deliveryStatus: "Failed"     (reason and reasonCode pre
 ```
 
 <Note>
-    If a message is delivered and read at the same time, for example when the recipient has the chat open,
-    the `Delivered` callback is skipped and only `Read` is sent.
+  If a message is delivered and read at the same time, for example when the
+  recipient has the chat open, the `Delivered` callback is skipped and only
+  `Read` is sent.
 </Note>
 
 ### Receipt Request
@@ -134,12 +145,12 @@ It must be included in the WhatsApp message request body when sending a message 
 ```
 
 | Field         | Type   | Constraints                                                                                                     |
-|---------------|--------|-----------------------------------------------------------------------------------------------------------------|
+| ------------- | ------ | --------------------------------------------------------------------------------------------------------------- |
 | `correlator`  | string | Non-empty, maximum 100 characters. Used to correlate callbacks to the originating request. Recommended: `UUID`. |
 | `callbackUrl` | string | Valid `https://` or `http://` URL. The endpoint must not require authentication.                                |
 
 <Warning>
-  When provided, both fields are required. An invalid `receiptRequest`
-  causes the entire request to be rejected with `400 Bad Request` before any
-  messages are dispatched.
+  When provided, both fields are required. An invalid `receiptRequest` causes
+  the entire request to be rejected with `400 Bad Request` before any messages
+  are dispatched.
 </Warning>

--- a/openapi.json
+++ b/openapi.json
@@ -30,9 +30,7 @@
       ],
       "post": {
         "operationId": "getAccessToken",
-        "tags": [
-          "Authentication"
-        ],
+        "tags": ["Authentication"],
         "security": [],
         "description": "Obtain an access token using client credentials flow",
         "requestBody": {
@@ -52,17 +50,11 @@
                   },
                   "grant_type": {
                     "type": "string",
-                    "enum": [
-                      "client_credentials"
-                    ],
+                    "enum": ["client_credentials"],
                     "default": "client_credentials"
                   }
                 },
-                "required": [
-                  "client_id",
-                  "client_secret",
-                  "grant_type"
-                ]
+                "required": ["client_id", "client_secret", "grant_type"]
               }
             }
           },
@@ -135,9 +127,7 @@
     "/service": {
       "get": {
         "operationId": "listServices",
-        "tags": [
-          "Service"
-        ],
+        "tags": ["Service"],
         "description": "Retrieve a list of available messaging services",
         "responses": {
           "200": {
@@ -206,9 +196,7 @@
     "/message/{serviceId}": {
       "post": {
         "operationId": "sendMessage",
-        "tags": [
-          "Message"
-        ],
+        "tags": ["Message"],
         "description": "Send a message to one or multiple recipients",
         "parameters": [
           {
@@ -234,9 +222,7 @@
                     "properties": {
                       "type": {
                         "type": "string",
-                        "enum": [
-                          "SendToEach"
-                        ],
+                        "enum": ["SendToEach"],
                         "description": "Indicates sending to a single recipient"
                       },
                       "messages": {
@@ -273,10 +259,7 @@
                         "additionalProperties": false
                       }
                     },
-                    "required": [
-                      "type",
-                      "messages"
-                    ]
+                    "required": ["type", "messages"]
                   },
                   {
                     "title": "SendToMany",
@@ -285,9 +268,7 @@
                     "properties": {
                       "type": {
                         "type": "string",
-                        "enum": [
-                          "SendToMany"
-                        ],
+                        "enum": ["SendToMany"],
                         "description": "Indicates sending to multiple recipients"
                       },
                       "message": {
@@ -317,11 +298,7 @@
                         "additionalProperties": false
                       }
                     },
-                    "required": [
-                      "type",
-                      "addresses",
-                      "message"
-                    ]
+                    "required": ["type", "addresses", "message"]
                   }
                 ]
               }
@@ -406,9 +383,7 @@
     "/message/{serviceId}/whatsapp": {
       "post": {
         "operationId": "sendWhatsAppMessage",
-        "tags": [
-          "Whatsapp"
-        ],
+        "tags": ["Whatsapp"],
         "description": "Sends a WhatsApp template message to one or more recipients via a configured WhatsApp Business Account (WABA). Only approved template messages are supported.",
         "parameters": [
           {
@@ -433,9 +408,7 @@
                     "properties": {
                       "type": {
                         "type": "string",
-                        "enum": [
-                          "TemplateSendToMany"
-                        ],
+                        "enum": ["TemplateSendToMany"],
                         "description": "Must be \"TemplateSendToMany\""
                       },
                       "phoneNumberId": {
@@ -474,10 +447,7 @@
                             "format": "uri"
                           }
                         },
-                        "required": [
-                          "correlator",
-                          "callbackUrl"
-                        ],
+                        "required": ["correlator", "callbackUrl"],
                         "additionalProperties": false
                       }
                     },
@@ -496,9 +466,7 @@
                     "properties": {
                       "type": {
                         "type": "string",
-                        "enum": [
-                          "TemplateSendToEach"
-                        ],
+                        "enum": ["TemplateSendToEach"],
                         "description": "Must be \"TemplateSendToEach\""
                       },
                       "phoneNumberId": {
@@ -526,10 +494,7 @@
                               }
                             }
                           },
-                          "required": [
-                            "phone",
-                            "params"
-                          ],
+                          "required": ["phone", "params"],
                           "additionalProperties": false
                         },
                         "description": "Per-recipient message objects. Maximum 10 per request"
@@ -548,10 +513,7 @@
                             "format": "uri"
                           }
                         },
-                        "required": [
-                          "correlator",
-                          "callbackUrl"
-                        ],
+                        "required": ["correlator", "callbackUrl"],
                         "additionalProperties": false
                       }
                     },
@@ -582,9 +544,7 @@
                       "properties": {
                         "type": {
                           "type": "string",
-                          "enum": [
-                            "WhatsAppResponse"
-                          ]
+                          "enum": ["WhatsAppResponse"]
                         },
                         "requestId": {
                           "type": "string",
@@ -598,18 +558,11 @@
                           "description": "Credit units consumed per Pricing Category. Currently always {}."
                         }
                       },
-                      "required": [
-                        "type",
-                        "requestId",
-                        "addresses",
-                        "units"
-                      ],
+                      "required": ["type", "requestId", "addresses", "units"],
                       "additionalProperties": false
                     }
                   },
-                  "required": [
-                    "result"
-                  ],
+                  "required": ["result"],
                   "additionalProperties": false
                 }
               }
@@ -668,9 +621,7 @@
     "/data/campaign": {
       "get": {
         "operationId": "listCampaigns",
-        "tags": [
-          "Campaign"
-        ],
+        "tags": ["Campaign"],
         "description": "Fetches all campaigns for the authenticated team.",
         "parameters": [
           {
@@ -742,9 +693,7 @@
     "/data/{campaignId}": {
       "post": {
         "operationId": "disburseData",
-        "tags": [
-          "Mobile Data"
-        ],
+        "tags": ["Mobile Data"],
         "description": "Disburse mobile data bundles to one or multiple recipients.",
         "parameters": [
           {
@@ -770,9 +719,7 @@
                     "properties": {
                       "type": {
                         "type": "string",
-                        "enum": [
-                          "SendToEach"
-                        ],
+                        "enum": ["SendToEach"],
                         "description": "Indicates per-recipient bundle disbursement mode"
                       },
                       "disbursements": {
@@ -815,10 +762,7 @@
                               "description": "Optional SMS notification sent after successful data disbursement (requires top-level messaging configuration)."
                             }
                           },
-                          "required": [
-                            "phone",
-                            "denomination"
-                          ],
+                          "required": ["phone", "denomination"],
                           "additionalProperties": false
                         },
                         "description": "List of recipients with individual denominations"
@@ -830,10 +774,7 @@
                         "$ref": "#/components/schemas/DataReceiptRequest"
                       }
                     },
-                    "required": [
-                      "type",
-                      "disbursements"
-                    ],
+                    "required": ["type", "disbursements"],
                     "allOf": [
                       {
                         "if": {
@@ -841,17 +782,13 @@
                             "disbursements": {
                               "contains": {
                                 "type": "object",
-                                "required": [
-                                  "message"
-                                ]
+                                "required": ["message"]
                               }
                             }
                           }
                         },
                         "then": {
-                          "required": [
-                            "messaging"
-                          ]
+                          "required": ["messaging"]
                         }
                       }
                     ],
@@ -864,9 +801,7 @@
                     "properties": {
                       "type": {
                         "type": "string",
-                        "enum": [
-                          "SendToMany"
-                        ],
+                        "enum": ["SendToMany"],
                         "description": "Indicates bulk disbursement mode"
                       },
                       "phones": {
@@ -908,11 +843,7 @@
                         "$ref": "#/components/schemas/DataReceiptRequest"
                       }
                     },
-                    "required": [
-                      "type",
-                      "phones",
-                      "denomination"
-                    ],
+                    "required": ["type", "phones", "denomination"],
                     "additionalProperties": false
                   }
                 ]
@@ -988,9 +919,7 @@
     "/bundle/{productType}": {
       "get": {
         "operationId": "listBundles",
-        "tags": [
-          "Bundle"
-        ],
+        "tags": ["Bundle"],
         "description": "Retrieve a list of bundles for a product type",
         "parameters": [
           {
@@ -999,10 +928,7 @@
             "required": true,
             "schema": {
               "type": "string",
-              "enum": [
-                "SMS",
-                "DATA_BUNDLE"
-              ]
+              "enum": ["SMS", "DATA_BUNDLE"]
             },
             "description": "Type of product associated with the bundle e.g SMS, DATA_BUNDLE"
           }
@@ -1094,9 +1020,7 @@
           },
           "token_type": {
             "type": "string",
-            "enum": [
-              "Bearer"
-            ],
+            "enum": ["Bearer"],
             "description": "Type of the token"
           },
           "not-before-policy": {
@@ -1148,12 +1072,7 @@
                     },
                     "status": {
                       "type": "string",
-                      "enum": [
-                        "Draft",
-                        "Active",
-                        "Offline",
-                        "Suspended"
-                      ],
+                      "enum": ["Draft", "Active", "Offline", "Suspended"],
                       "default": "Draft",
                       "description": "Status of the service"
                     },
@@ -1163,10 +1082,7 @@
                       "description": "Timestamp when the service was created"
                     },
                     "updatedAt": {
-                      "type": [
-                        "string",
-                        "null"
-                      ],
+                      "type": ["string", "null"],
                       "format": "date-time",
                       "description": "Timestamp when the service was last updated"
                     }
@@ -1285,10 +1201,7 @@
           },
           "status": {
             "type": "string",
-            "enum": [
-              "Active",
-              "Archived"
-            ],
+            "enum": ["Active", "Archived"],
             "description": "Status of the campaign"
           },
           "rules": {
@@ -1328,10 +1241,7 @@
             "description": "List of allowed denominations"
           },
           "expiry": {
-            "type": [
-              "string",
-              "null"
-            ],
+            "type": ["string", "null"],
             "format": "date-time",
             "description": "Optional expiry timestamp"
           }
@@ -1371,9 +1281,7 @@
                 "description": "Uses the campaign/product default SMS service"
               }
             },
-            "required": [
-              "type"
-            ],
+            "required": ["type"],
             "additionalProperties": false
           },
           {
@@ -1390,10 +1298,7 @@
                 "description": "Unique identifier of the SMS service to use"
               }
             },
-            "required": [
-              "type",
-              "serviceId"
-            ],
+            "required": ["type", "serviceId"],
             "additionalProperties": false
           }
         ]
@@ -1406,9 +1311,7 @@
             "$ref": "#/components/schemas/MessagingServiceSelection"
           }
         },
-        "required": [
-          "serviceSelection"
-        ],
+        "required": ["serviceSelection"],
         "additionalProperties": false
       },
       "DataMessagingToMany": {
@@ -1425,10 +1328,7 @@
             "$ref": "#/components/schemas/MessagingServiceSelection"
           }
         },
-        "required": [
-          "message",
-          "serviceSelection"
-        ],
+        "required": ["message", "serviceSelection"],
         "additionalProperties": false
       },
       "DataReceiptRequest": {
@@ -1446,10 +1346,7 @@
             "description": "Public HTTPS callback URL to receive delivery receipts"
           }
         },
-        "required": [
-          "correlator",
-          "callbackUrl"
-        ],
+        "required": ["correlator", "callbackUrl"],
         "additionalProperties": false
       },
       "DataDisbursementResponse": {
@@ -1510,10 +1407,7 @@
                   "properties": {
                     "type": {
                       "type": "string",
-                      "enum": [
-                        "DataBundleResponse",
-                        "SmsBundleResponse"
-                      ],
+                      "enum": ["DataBundleResponse", "SmsBundleResponse"],
                       "description": "Type of product associated with the bundle"
                     },
                     "reference": {
@@ -1572,10 +1466,7 @@
                           },
                           "channel": {
                             "type": "string",
-                            "enum": [
-                              "Safaricom",
-                              "Airtel"
-                            ],
+                            "enum": ["Safaricom", "Airtel"],
                             "description": "Network channel associated with the balance"
                           },
                           "denomination": {
@@ -1624,10 +1515,7 @@
                       }
                     },
                     "validity": {
-                      "type": [
-                        "string",
-                        "null"
-                      ],
+                      "type": ["string", "null"],
                       "description": "Validity period of the bundle e.g 30 days"
                     },
                     "createdAt": {
@@ -1636,10 +1524,7 @@
                       "description": "Timestamp when the bundle was created"
                     },
                     "updatedAt": {
-                      "type": [
-                        "string",
-                        "null"
-                      ],
+                      "type": ["string", "null"],
                       "format": "date-time",
                       "description": "Timestamp when the bundle was last updated"
                     }
@@ -1677,6 +1562,7 @@
         "description": "Current WhatsApp delivery state.",
         "enum": [
           "Sent",
+          "Waiting",
           "Delivered",
           "Read",
           "Failed",
@@ -1687,11 +1573,7 @@
       "WhatsAppPricingType": {
         "type": "string",
         "description": "WhatsApp billing type applied to this message.",
-        "enum": [
-          "Regular",
-          "FreeCustomerService",
-          "FreeEntryPoint"
-        ]
+        "enum": ["Regular", "FreeCustomerService", "FreeEntryPoint"]
       },
       "WhatsAppPricingCategory": {
         "type": "string",
@@ -1716,10 +1598,7 @@
             "$ref": "#/components/schemas/WhatsAppPricingCategory"
           }
         },
-        "required": [
-          "type",
-          "category"
-        ],
+        "required": ["type", "category"],
         "additionalProperties": false
       },
       "TemplateParameter": {
@@ -1774,18 +1653,11 @@
       },
       "PositionalTemplateParameter": {
         "type": "object",
-        "required": [
-          "type",
-          "position",
-          "value"
-        ],
+        "required": ["type", "position", "value"],
         "properties": {
           "type": {
             "type": "string",
-            "enum": [
-              "BodyPositionalParameter",
-              "HeaderPositionalParameter"
-            ]
+            "enum": ["BodyPositionalParameter", "HeaderPositionalParameter"]
           },
           "position": {
             "type": "integer",
@@ -1801,18 +1673,11 @@
       },
       "NamedTemplateParameter": {
         "type": "object",
-        "required": [
-          "type",
-          "name",
-          "value"
-        ],
+        "required": ["type", "name", "value"],
         "properties": {
           "type": {
             "type": "string",
-            "enum": [
-              "BodyNamedParameter",
-              "HeaderNamedParameter"
-            ]
+            "enum": ["BodyNamedParameter", "HeaderNamedParameter"]
           },
           "name": {
             "type": "string",
@@ -1828,10 +1693,7 @@
       },
       "MediaTemplateParameter": {
         "type": "object",
-        "required": [
-          "type",
-          "url"
-        ],
+        "required": ["type", "url"],
         "properties": {
           "type": {
             "type": "string",
@@ -1852,11 +1714,7 @@
       },
       "LocationTemplateParameter": {
         "type": "object",
-        "required": [
-          "type",
-          "latitude",
-          "longitude"
-        ],
+        "required": ["type", "latitude", "longitude"],
         "properties": {
           "type": {
             "type": "string",
@@ -1883,10 +1741,7 @@
       },
       "CopyParameter": {
         "type": "object",
-        "required": [
-          "type",
-          "value"
-        ],
+        "required": ["type", "value"],
         "properties": {
           "type": {
             "type": "string",
@@ -1901,10 +1756,7 @@
       },
       "TimeToLiveParameter": {
         "type": "object",
-        "required": [
-          "type",
-          "minutes"
-        ],
+        "required": ["type", "minutes"],
         "properties": {
           "type": {
             "type": "string",
@@ -1920,10 +1772,7 @@
       },
       "VoiceCallPayloadParameter": {
         "type": "object",
-        "required": [
-          "type",
-          "payload"
-        ],
+        "required": ["type", "payload"],
         "properties": {
           "type": {
             "type": "string",
@@ -1938,10 +1787,7 @@
       },
       "OtpParameter": {
         "type": "object",
-        "required": [
-          "type",
-          "code"
-        ],
+        "required": ["type", "code"],
         "properties": {
           "type": {
             "type": "string",
@@ -1956,11 +1802,7 @@
       },
       "UrlNamedParameter": {
         "type": "object",
-        "required": [
-          "type",
-          "name",
-          "value"
-        ],
+        "required": ["type", "name", "value"],
         "properties": {
           "type": {
             "type": "string",
@@ -1979,11 +1821,7 @@
       },
       "UrlPositionalParameter": {
         "type": "object",
-        "required": [
-          "type",
-          "position",
-          "value"
-        ],
+        "required": ["type", "position", "value"],
         "properties": {
           "type": {
             "type": "string",
@@ -2002,10 +1840,7 @@
       },
       "CouponCodeParameter": {
         "type": "object",
-        "required": [
-          "type",
-          "code"
-        ],
+        "required": ["type", "code"],
         "properties": {
           "type": {
             "type": "string",
@@ -2020,10 +1855,7 @@
       },
       "QuickReplyPayloadParameter": {
         "type": "object",
-        "required": [
-          "type",
-          "payload"
-        ],
+        "required": ["type", "payload"],
         "properties": {
           "type": {
             "type": "string",
@@ -2038,10 +1870,7 @@
       },
       "LimitedTimeOfferParameter": {
         "type": "object",
-        "required": [
-          "type",
-          "expiresAt"
-        ],
+        "required": ["type", "expiresAt"],
         "properties": {
           "type": {
             "type": "string",
@@ -2057,11 +1886,7 @@
       },
       "CarouselCardParameter": {
         "type": "object",
-        "required": [
-          "type",
-          "cardIndex",
-          "params"
-        ],
+        "required": ["type", "cardIndex", "params"],
         "properties": {
           "type": {
             "type": "string",
@@ -2107,11 +1932,7 @@
             "type": "string"
           }
         },
-        "required": [
-          "type",
-          "parameterType",
-          "error"
-        ],
+        "required": ["type", "parameterType", "error"],
         "additionalProperties": false
       },
       "TemplateComponentError": {
@@ -2128,11 +1949,7 @@
             "type": "string"
           }
         },
-        "required": [
-          "type",
-          "componentType",
-          "error"
-        ],
+        "required": ["type", "componentType", "error"],
         "additionalProperties": false
       },
       "TemplateSendToManyValidationResult": {
@@ -2145,18 +1962,14 @@
             }
           }
         },
-        "required": [
-          "errors"
-        ],
+        "required": ["errors"],
         "additionalProperties": false
       },
       "TemplateSendToEachValidationResult": {
         "type": "object",
         "description": "Validation errors keyed by recipient phone number. Only recipients with failures are included.",
         "not": {
-          "required": [
-            "errors"
-          ]
+          "required": ["errors"]
         },
         "additionalProperties": {
           "type": "array",
@@ -2183,64 +1996,7 @@
             ]
           }
         },
-        "required": [
-          "desc",
-          "result"
-        ],
-        "additionalProperties": false
-      },
-      "WhatsAppOutboundMessageReceipt": {
-        "type": "object",
-        "description": "Callback payload posted to the receiptRequest.callbackUrl when a message delivery status changes.",
-        "properties": {
-          "type": {
-            "type": "string",
-            "const": "WhatsAppOutboundMessageReceipt",
-            "description": "Always \"WhatsAppOutboundMessageReceipt\""
-          },
-          "wamId": {
-            "type": "string",
-            "description": "WhatsApp message ID assigned by Meta. May be omitted when deliveryStatus is Failed and termination to Meta was not successful."
-          },
-          "correlator": {
-            "type": "string",
-            "description": "Unique ID that correlates with the original message request."
-          },
-          "phone": {
-            "type": "string",
-            "description": "Recipient phone number in E.164 format without the leading +."
-          },
-          "timestamp": {
-            "type": "string",
-            "format": "date-time",
-            "description": "When the status event occurred in UTC."
-          },
-          "deliveryStatus": {
-            "$ref": "#/components/schemas/WhatsAppDeliveryStatus"
-          },
-          "conversationId": {
-            "type": "string",
-            "description": "WhatsApp conversation window ID. Present only for selected non-failed status callbacks."
-          },
-          "pricing": {
-            "$ref": "#/components/schemas/WhatsAppPricing"
-          },
-          "reason": {
-            "type": "string",
-            "description": "Human-readable failure reason; present when deliveryStatus is \"Failed\""
-          },
-          "reasonCode": {
-            "type": "string",
-            "description": "Machine-readable error code; present when deliveryStatus is \"Failed\""
-          }
-        },
-        "required": [
-          "type",
-          "correlator",
-          "phone",
-          "timestamp",
-          "deliveryStatus"
-        ],
+        "required": ["desc", "result"],
         "additionalProperties": false
       }
     },


### PR DESCRIPTION
### Summary
This PR updates the WhatsApp outbound delivery receipt documentation to match the latest callback payload shape.

### What Changed
- Updated WhatsApp delivery receipt examples and field definitions:
    - Added mandatory identifiers for business account context:
       - `wabaId`
       - `phoneNumberId`
   - Replaced phone with explicit sender and recipient fields in examples and field table.